### PR TITLE
feat: Create load balancer from workspace annotation

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -22,10 +22,22 @@ import (
 )
 
 const (
+
+	// Non-prefixed labels/annotations are reserved for end-use.
+
+	// KDMPrefix Kubernetes Data Mining prefix.
+	KDMPrefix = "kubernetes-kdm.io/"
+
 	PresetSetModelllama2A            PresetModelName = "llama2-7b"
 	PresetSetModelllama2B            PresetModelName = "llama2-13b"
 	PresetSetModelllama2C            PresetModelName = "llama2-70b"
 	PresetSetModelStableDiffusionXXX PresetModelName = "stablediffusion-xxx"
+
+	// AnnotationServiceType determines whether kdm creates ClusterIP or LoadBalancer type service.
+	AnnotationServiceType = KDMPrefix + "service-type"
+
+	ServiceTypeClusterIP    = "cluster-ip"
+	ServiceTypeLoadBalancer = "load-balancer"
 )
 
 type ResourceSpec struct {

--- a/config/rbac/workspace_editor_role.yaml
+++ b/config/rbac/workspace_editor_role.yaml
@@ -11,51 +11,24 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: workspace-editor-role
 rules:
-  - apiGroups:
-      - kdm.io
-    resources:
-      - workspaces
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - kdm.io
-    resources:
-      - workspaces/status
-    verbs:
-      - create
-      - delete
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - namespaces
-    verbs:
-      - patch
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - create
-      - patch
-      - update
-  - apiGroups:
-      - "apps"
-    resources:
-      - daemonsets
-    verbs:
-      - patch
-      - update
-      - get
+  - apiGroups: ["kdm.io"]
+    resources: ["workspaces"]
+    verbs: ["create", "delete", "update", "patch","get","list","watch"]
+  - apiGroups: ["kdm.io"]
+    resources: ["workspaces/status"]
+    verbs: ["create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes", "namespaces"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "update", "patch"]
+  - apiGroups: [ "" ]
+    resources: [ "pods"]
+    verbs: [ "create", "update", "patch" ]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["update", "patch", "get"]
   - apiGroups: ["karpenter.sh"]
     resources: ["machines", "machines/status"]
     verbs: ["create", "delete", "update", "patch"]

--- a/config/samples/kdm_v1alpha1_workspace.yaml
+++ b/config/samples/kdm_v1alpha1_workspace.yaml
@@ -1,6 +1,8 @@
 apiVersion: kdm.io/v1alpha1
 kind: Workspace
 metadata:
+  annotations:
+    kubernetes-kdm.io/service-type : load-balancer
   labels:
     app.kubernetes.io/name: workspace
     app.kubernetes.io/instance: workspace-sample
@@ -16,5 +18,4 @@ resource:
       gpu-provisioner.sh/machine-type: gpu
   preferredNodes:
     - "node1"
-    - "aks-machine1-33538733-vmss000000"
-    - "aks-nodepool1-88161285-vmss000000"
+    - "aks-machine98722-26559722-vmss000001"

--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,34 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace (
+	k8s.io/api => k8s.io/api v0.27.2
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.27.2
+	k8s.io/apimachinery => k8s.io/apimachinery v0.27.2
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.27.2
+	k8s.io/client-go => k8s.io/client-go v0.27.2
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.27.2
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.27.2
+	k8s.io/code-generator => k8s.io/code-generator v0.27.2
+	k8s.io/component-base => k8s.io/component-base v0.27.2
+	k8s.io/component-helpers => k8s.io/component-helpers v0.27.2
+	k8s.io/controller-manager => k8s.io/controller-manager v0.27.2
+	k8s.io/cri-api => k8s.io/cri-api v0.27.2
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.27.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.27.2
+	k8s.io/kms => k8s.io/kms v0.27.2
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.27.2
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.27.2
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.27.2
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.27.2
+	k8s.io/kubectl => k8s.io/kubectl v0.27.2
+	k8s.io/kubelet => k8s.io/kubelet v0.27.2
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.27.2
+	k8s.io/metrics => k8s.io/metrics v0.27.2
+	k8s.io/mount-utils => k8s.io/mount-utils v0.27.2
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.27.2
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.27.2
+	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.27.2
+	k8s.io/sample-controller => k8s.io/sample-controller v0.27.2
+)

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -3,12 +3,13 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/go-logr/logr"
 	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	"github.com/kdm/pkg/k8sresources"
 	"github.com/kdm/pkg/machine"
-	"github.com/kdm/pkg/node"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -49,6 +50,7 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 	}
 
 	return c.addOrUpdateWorkspace(ctx, workspaceObj)
+
 }
 
 func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *kdmv1alpha1.Workspace) (reconcile.Result, error) {
@@ -59,6 +61,14 @@ func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *kd
 	}
 	// TODO apply InferenceSpec
 	// TODO apply TrainingSpec
+
+	if wObj.GetAnnotations() != nil {
+		err := c.applyAnnotations(ctx, wObj)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
 	err = c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeReady, metav1.ConditionTrue, "workspaceReady", "workspace is ready")
 	if err != nil {
 		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
@@ -184,7 +194,7 @@ func (c *WorkspaceReconciler) validateCurrentClusterNodes(ctx context.Context, w
 		return nil, nil
 	}
 
-	nodeList, err := node.ListNodes(ctx, c.Client, opt)
+	nodeList, err := k8sresources.ListNodes(ctx, c.Client, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +279,7 @@ func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *k
 	if nodeName == "" {
 		// TODO retry get machine
 	}
-	nodeObj, err := node.GetNode(ctx, nodeName, c.Client)
+	nodeObj, err := k8sresources.GetNode(ctx, nodeName, c.Client)
 	if err != nil {
 		if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineProvisioned, metav1.ConditionFalse,
 			"machineFailedProvision", err.Error()); err != nil {
@@ -303,9 +313,9 @@ func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kdmv1
 			}
 
 			//Nvidia Plugin
-			foundNvidiaPlugin = node.CheckNvidiaPlugin(ctx, nodeObj)
+			foundNvidiaPlugin = k8sresources.CheckNvidiaPlugin(ctx, nodeObj)
 			if !foundNvidiaPlugin {
-				err := node.UpdateNodeWithLabel(ctx, nodeObj.Name, node.LabelKeyNvidia, node.LabelValueNvidia, c.Client)
+				err := k8sresources.UpdateNodeWithLabel(ctx, nodeObj.Name, k8sresources.LabelKeyNvidia, k8sresources.LabelValueNvidia, c.Client)
 				if err != nil {
 					if errors.IsNotFound(err) {
 						klog.ErrorS(fmt.Errorf("nvidia plugin cannot be installed, node not found"), "node", nodeObj.Name)
@@ -320,9 +330,9 @@ func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kdmv1
 			}
 
 			//DADI plugin
-			err := node.CheckDADIPlugin(ctx, nodeObj, c.Client)
+			err := k8sresources.CheckDADIPlugin(ctx, nodeObj, c.Client)
 			if err != nil {
-				err = node.UpdateNodeWithLabel(ctx, nodeObj.Name, node.LabelKeyCustomGPUProvisioner, node.GPUString, c.Client)
+				err = k8sresources.UpdateNodeWithLabel(ctx, nodeObj.Name, k8sresources.LabelKeyCustomGPUProvisioner, k8sresources.GPUString, c.Client)
 				if err != nil {
 					if errors.IsNotFound(err) {
 						klog.ErrorS(fmt.Errorf("DADI plugin cannot be installed, node not found"), "node", nodeObj.Name)
@@ -355,6 +365,30 @@ func (c *WorkspaceReconciler) setConditionInstallNodePluginsToUnknown(ctx contex
 		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
 		return err
 	}
+	return nil
+}
+
+func (c *WorkspaceReconciler) applyAnnotations(ctx context.Context, wObj *kdmv1alpha1.Workspace) error {
+	klog.InfoS("applyAnnotations", "workspace", klog.KObj(wObj))
+	wAnnotation := wObj.GetAnnotations()
+
+	if wAnnotation == nil {
+		klog.InfoS("no annotations have been set for the workspace", "workspace", wObj.Name)
+		return nil
+	}
+
+	// Load-balancer
+	annotKey, found := lo.FindKey(wAnnotation, kdmv1alpha1.ServiceTypeLoadBalancer)
+	if !found {
+		return fmt.Errorf("service type annotation is not set correctly. key: %s, value: %s", annotKey, kdmv1alpha1.ServiceTypeLoadBalancer)
+	}
+	serviceObj := k8sresources.GenerateLoadBalancerService(ctx, fmt.Sprint("workspace", "-lb", rand.Intn(100)), wObj.Namespace, corev1.ServiceTypeLoadBalancer, wObj.Resource.LabelSelector.MatchLabels)
+
+	err := k8sresources.CreateLoadBalancerService(ctx, serviceObj, c.Client)
+	if err != nil {
+		return err
+	}
+	klog.InfoS("a load balancer has been created")
 	return nil
 }
 

--- a/pkg/k8sresources/nodes.go
+++ b/pkg/k8sresources/nodes.go
@@ -1,4 +1,4 @@
-package node
+package k8sresources
 
 import (
 	"context"

--- a/pkg/k8sresources/services.go
+++ b/pkg/k8sresources/services.go
@@ -1,0 +1,43 @@
+package k8sresources
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateLoadBalancerService(ctx context.Context, serviceObj *v1.Service, kubeClient client.Client) error {
+	klog.InfoS("CreateLoadBalancerService", "service", klog.KObj(serviceObj))
+	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		return kubeClient.Create(ctx, serviceObj, &client.CreateOptions{})
+	})
+}
+
+func GenerateLoadBalancerService(ctx context.Context, serviceName, namespace string, serviceType v1.ServiceType, labelSelector map[string]string) *v1.Service {
+	klog.InfoS("GenerateLoadBalancerService", "serviceName", serviceName, "namespace", "serviceType", serviceType)
+
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+		},
+		Spec: v1.ServiceSpec{
+			Type: serviceType, //v1.ServiceTypeLoadBalancer,
+			Ports: []v1.ServicePort{
+				{
+					Protocol:   v1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromInt(5000),
+				},
+			},
+			Selector: labelSelector,
+		},
+	}
+}


### PR DESCRIPTION
Implement the feature that gives workspace CR users the ability to create a load-balancer [*](https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/#load-balancer-selection-modes) with the same label selectors set in `resource.LabelSelector`