### PR TITLE
feat: Add timeout for machine check status and return when SKU is not available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/client-go v0.27.2
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kubernetes v1.27.2
+	k8s.io/utils v0.0.0-20230209194617-a36077c30491
 	knative.dev/pkg v0.0.0-20230502134655-db8a35330281
 	sigs.k8s.io/controller-runtime v0.15.2
 )
@@ -20,6 +21,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
@@ -66,7 +68,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
-	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
+github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/inference/preset-llama2-inferences.go
+++ b/pkg/inference/preset-llama2-inferences.go
@@ -3,14 +3,17 @@ package inference
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
 	"github.com/kdm/pkg/k8sresources"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,6 +32,9 @@ const (
 )
 
 var (
+	deploymentStatusCheckInterval                  = 600 * time.Second
+	timeClock                     clock.WithTicker = clock.RealClock{}
+
 	containerPorts = []corev1.ContainerPort{{
 		ContainerPort: Port5000,
 	},
@@ -41,7 +47,7 @@ var (
 				Path: ProbePath,
 			},
 		},
-		InitialDelaySeconds: 60,
+		InitialDelaySeconds: 600, // 10 minutes
 		PeriodSeconds:       10,
 	}
 
@@ -90,11 +96,14 @@ func CreateLLAMA2APresetModel(ctx context.Context, workspaceName, namespace stri
 		})
 	}
 
-	depObj := k8sresources.GenerateDeploymentManifest(ctx, fmt.Sprint(workspaceName, string(kdmv1alpha1.PresetSetModelllama2A)), namespace,
+	depObj := k8sresources.GenerateDeploymentManifest(ctx, fmt.Sprint(workspaceName, "-", string(kdmv1alpha1.PresetSetModelllama2A)), namespace,
 		PresetSetModelllama2AChatImage, 1, labelSelector, commands, containerPorts, livenessProbe, readinessProbe,
 		resourceRequirements, volumeMount, tolerations, volume)
 	err := k8sresources.CreateDeployment(ctx, depObj, kubeClient)
 	if err != nil {
+		return err
+	}
+	if err := checkDeploymentStatus(ctx, depObj, kubeClient); err != nil {
 		return err
 	}
 	return nil
@@ -125,8 +134,12 @@ func CreateLLAMA2BPresetModel(ctx context.Context, workspaceName, namespace stri
 	depObj := k8sresources.GenerateDeploymentManifest(ctx, fmt.Sprint(workspaceName, string(kdmv1alpha1.PresetSetModelllama2B)), namespace,
 		PresetSetModelllama2BChatImage, 1, labelSelector, commands, containerPorts, livenessProbe, readinessProbe,
 		resourceRequirements, volumeMount, tolerations, volume)
-	err := k8sresources.CreateDeployment(ctx, depObj, kubeClient)
-	if err != nil {
+
+	if err := k8sresources.CreateDeployment(ctx, depObj, kubeClient); err != nil {
+		return err
+	}
+
+	if err := checkDeploymentStatus(ctx, depObj, kubeClient); err != nil {
 		return err
 	}
 	return nil
@@ -158,11 +171,46 @@ func CreateLLAMA2CPresetModel(ctx context.Context, workspaceName, namespace stri
 		PresetSetModelllama2CChatImage, 1, labelSelector, commands, containerPorts, livenessProbe, readinessProbe,
 		resourceRequirements, volumeMount, tolerations, volume)
 
-	err := k8sresources.CreateDeployment(ctx, depObj, kubeClient)
-	if err != nil {
+	if err := k8sresources.CreateDeployment(ctx, depObj, kubeClient); err != nil {
+		return err
+	}
+
+	if err := checkDeploymentStatus(ctx, depObj, kubeClient); err != nil {
 		return err
 	}
 	return nil
+}
+
+func checkDeploymentStatus(ctx context.Context, depObj *appsv1.Deployment, kubeClient client.Client) error {
+	klog.InfoS("checkDeploymentStatus", "deployment", depObj.Name)
+
+	tick := timeClock.NewTicker(deploymentStatusCheckInterval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-tick.C():
+			return fmt.Errorf("check deployment status timed out. deployment %s is not ready", depObj.Name)
+		default:
+
+			err := kubeClient.Get(ctx, client.ObjectKey{
+				Name:      depObj.Name,
+				Namespace: depObj.Namespace,
+			}, depObj)
+			if err != nil {
+				return err
+			}
+			if depObj.Status.ReadyReplicas != 1 {
+				continue
+			}
+
+			klog.InfoS("machine status is ready", "machine", depObj.Name)
+			return nil
+		}
+	}
 }
 
 func buildCommand(baseCommand string, torchRunParams map[string]string) []string {

--- a/pkg/inference/preset-llama2-inferences.go
+++ b/pkg/inference/preset-llama2-inferences.go
@@ -195,7 +195,7 @@ func checkDeploymentStatus(ctx context.Context, depObj *appsv1.Deployment, kubeC
 		case <-tick.C():
 			return fmt.Errorf("check deployment status timed out. deployment %s is not ready", depObj.Name)
 		default:
-
+			time.Sleep(1 * time.Second)
 			err := kubeClient.Get(ctx, client.ObjectKey{
 				Name:      depObj.Name,
 				Namespace: depObj.Namespace,
@@ -207,7 +207,7 @@ func checkDeploymentStatus(ctx context.Context, depObj *appsv1.Deployment, kubeC
 				continue
 			}
 
-			klog.InfoS("machine status is ready", "machine", depObj.Name)
+			klog.InfoS("inference deployment status is ready", "deployment", depObj.Name)
 			return nil
 		}
 	}

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -10,21 +10,28 @@ import (
 	"github.com/kdm/api/v1alpha1"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	ProvisionerName           = "default"
-	LabelGPUProvisionerCustom = "gpu-provisioner.sh/machine-type"
-	LabelProvisionerName      = "karpenter.sh/provisioner-name"
-	GPUString                 = "gpu"
+	ProvisionerName               = "default"
+	LabelGPUProvisionerCustom     = "gpu-provisioner.sh/machine-type"
+	LabelProvisionerName          = "karpenter.sh/provisioner-name"
+	GPUString                     = "gpu"
+	ErrorInstanceTypesUnavailable = "all requested instance types were unavailable during launch"
 )
 
+var (
+	machineStatusCheckInterval                  = 60 * time.Second
+	timeClock                  clock.WithTicker = clock.RealClock{}
+)
+
+// GenerateMachineManifest generates a machine object from	the given workspace.
 func GenerateMachineManifest(ctx context.Context, workspaceObj *v1alpha1.Workspace) *v1alpha5.Machine {
 	klog.InfoS("GenerateMachineManifest", "workspace", klog.KObj(workspaceObj))
 
@@ -86,39 +93,67 @@ func GenerateMachineManifest(ctx context.Context, workspaceObj *v1alpha1.Workspa
 	}
 }
 
+// CreateMachine creates a machine object.
 func CreateMachine(ctx context.Context, machineObj *v1alpha5.Machine, kubeClient client.Client) error {
 	klog.InfoS("CreateMachine", "machine", klog.KObj(machineObj))
 	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
-		return true
+		return err.Error() != ErrorInstanceTypesUnavailable
 	}, func() error {
-		return kubeClient.Create(ctx, machineObj, &client.CreateOptions{})
+		err := kubeClient.Create(ctx, machineObj, &client.CreateOptions{})
+		if err != nil {
+			return err
+		}
+		time.Sleep(1 * time.Second)
+
+		updatedObj := &v1alpha5.Machine{}
+		err = kubeClient.Get(ctx, client.ObjectKey{Name: machineObj.Name, Namespace: machineObj.Namespace}, updatedObj, &client.GetOptions{})
+
+		// if SKU is not available, then exit.
+		_, conditionFound := lo.Find(updatedObj.GetConditions(), func(condition apis.Condition) bool {
+			return condition.Type == v1alpha5.MachineLaunched &&
+				condition.Status == v1.ConditionFalse && condition.Message == ErrorInstanceTypesUnavailable
+		})
+		if conditionFound {
+			klog.Error(ErrorInstanceTypesUnavailable, "reconcile will not continue")
+			return fmt.Errorf(ErrorInstanceTypesUnavailable)
+		}
+		return err
 	})
 }
 
+// CheckMachineStatus checks the status of the machine. If the machine is not ready, then it will wait for the machine to be ready.
+// If the machine is not ready after the timeout, then it will return an error.
+// if	the machine is ready, then it will return nil.
 func CheckMachineStatus(ctx context.Context, machineObj *v1alpha5.Machine, kubeClient client.Client) error {
 	klog.InfoS("CheckMachineStatus", "machine", klog.KObj(machineObj))
+
+	tick := timeClock.NewTicker(machineStatusCheckInterval)
+	defer tick.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+
+		case <-tick.C():
+			return fmt.Errorf("check machine status timed out. machine %s is not ready", machineObj.Name)
+
 		default:
 			time.Sleep(1 * time.Second)
 			err := kubeClient.Get(ctx, client.ObjectKey{Name: machineObj.Name, Namespace: machineObj.Namespace}, machineObj, &client.GetOptions{})
 			if err != nil {
-				if apierrors.IsNotFound(err) {
-					continue
-				} else {
-					return err
-				}
+				return err
 			}
-			_, found := lo.Find(machineObj.GetConditions(), func(condition apis.Condition) bool {
+
+			// if machine is not ready, then continue.
+			_, conditionFound := lo.Find(machineObj.GetConditions(), func(condition apis.Condition) bool {
 				return condition.Type == apis.ConditionReady &&
 					condition.Status == v1.ConditionTrue
 			})
-			if !found {
+			if !conditionFound {
 				continue
 			}
+
 			klog.InfoS("machine status is ready", "machine", machineObj.Name)
 			return nil
 		}


### PR DESCRIPTION
- Add timeout for machine check status (60 seconds)
- Add timeout for inference deployment check status as 10 minutes. 
-  Stop re-queuing the workspace reconciler if SKU is not available.
- Increase MaxConcurrentReconciles to 5
- Increase the liveness probe's initial time to 10 minutes