### PR TITLE
feat: Merge machine conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,9 @@ az aks create --name kdm-aks --resource-group kdm-rg --node-count 1  --generate-
 git clone https://github.com/Fei-Guo/gpu-vmprovisioner.git
 cd gpu-vmprovisioner
 
-export AZURE_SUBSCRIPTION_ID=<your_subscription_id>
-export AZURE_LOCATION=<Azure_region>
-export AZURE_RESOURCE_GROUP=<your_resource_group_name>
-export AZURE_ACR_NAME=<you_Azure_container_registry_name>
-export AZURE_CLUSTER_NAME=<you_AKS_cluster_name>
-
-make az-perm
-make az-patch-skaffold-kubenet
-make az-run
+AZURE_SUBSCRIPTION_ID=<your_subscription_id> AZURE_LOCATION=<Azure_region> \
+AZURE_RESOURCE_GROUP=<your_resource_group_name> AZURE_ACR_NAME=<you_Azure_container_registry_name> \
+AZURE_CLUSTER_NAME=<you_AKS_cluster_name> make az-perm az-patch-skaffold-kubenet az-run
 ```
 3. Build and push docker image
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ az aks create --name kdm-aks --resource-group kdm-rg --node-count 1  --generate-
 git clone https://github.com/Fei-Guo/gpu-vmprovisioner.git
 cd gpu-vmprovisioner
 
+export AZURE_SUBSCRIPTION_ID=<your_subscription_id>
+export AZURE_LOCATION=<Azure_region>
+export AZURE_RESOURCE_GROUP=<your_resource_group_name>
+export AZURE_ACR_NAME=<you_Azure_container_registry_name>
+export AZURE_CLUSTER_NAME=<you_AKS_cluster_name>
+
 make az-perm
 make az-patch-skaffold-kubenet
 make az-run

--- a/api/v1alpha1/workspace_condition_types.go
+++ b/api/v1alpha1/workspace_condition_types.go
@@ -16,9 +16,6 @@ const (
 	// WorkspaceConditionTypeMachineStatus is the state when checking machine status.
 	WorkspaceConditionTypeMachineStatus = ConditionType("MachineReady")
 
-	// WorkspaceConditionTypeInstallNodePlugins is the state when installing node plugins.
-	WorkspaceConditionTypeInstallNodePlugins = ConditionType("NodePluginsInstalled")
-
 	// WorkspaceConditionTypeResourceDeleted is the state when Resources have been deleted.
 	WorkspaceConditionTypeResourceDeleted = ConditionType("ResourceDeleted")
 

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -42,17 +42,21 @@ const (
 
 type ResourceSpec struct {
 	// The number of required GPU nodes.
+	//+optional
+	//+kubebuilder:default:=1
 	Count *int `json:"count,omitempty"`
 
 	// The required instance type of the GPU node.
 	InstanceType string `json:"instanceType,omitempty"`
 
 	// The required label for the GPU node.
+	//+optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 
 	// The existing GPU nodes with the required labels and the required instanceType.
 	// This field is used when the number of qualified existing nodes is larger than the required count.
 	// Users need to ensure supported VHD images are installed in the VMs.
+	//+optional
 	PreferredNodes []string `json:"preferredNodes,omitempty"`
 }
 
@@ -93,11 +97,12 @@ type WorkspaceStatus struct {
 	Conditions []metav1.Condition `json:"condition,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name="MachineReady",type="string",JSONPath=".status.conditions[?(@.type==\"MachineReady\")].status",description=""
-//+kubebuilder:printcolumn:name="WorkspaceReady",type="string",JSONPath=".status.conditions[?(@.type==\"WorkspaceReady\")].status",description=""
 // Workspace is the Schema for the workspaces API
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=workspaces,scope=Namespaced
+// +kubebuilder:printcolumn:name="MachineReady",type="string",JSONPath=".status.conditions[?(@.type==\"MachineReady\")].status",description=""
+// +kubebuilder:printcolumn:name="WorkspaceReady",type="string",JSONPath=".status.conditions[?(@.type==\"WorkspaceReady\")].status",description=""
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/kdm.io_workspaces.yaml
+++ b/config/crd/bases/kdm.io_workspaces.yaml
@@ -61,6 +61,7 @@ spec:
           resource:
             properties:
               count:
+                default: 1
                 description: The number of required GPU nodes.
                 type: integer
               instanceType:

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
-github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -3,9 +3,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/go-logr/logr"
 	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
 	"github.com/kdm/pkg/inference"
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -104,7 +105,7 @@ func (c *WorkspaceReconciler) deleteWorkspace(ctx context.Context, wObj *kdmv1al
 	return c.garbageCollectWorkspace(ctx, wObj)
 }
 
-// applyAnnotations applies workspace resource spec.
+// applyWorkspaceResource applies workspace resource spec.
 func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *kdmv1alpha1.Workspace) error {
 	klog.InfoS("applyWorkspaceResource", "workspace", klog.KObj(wObj))
 	validNodeList := []*corev1.Node{}
@@ -113,6 +114,11 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 	if lo.FromPtr(wObj.Resource.Count) == 0 {
 		klog.InfoS("resource count is not set, default (count = 1) will be used", "workspace", klog.KObj(wObj))
 		wObj.Resource.Count = lo.ToPtr(1)
+	}
+
+	machinesProvisioningCount, err := machine.CheckOngoingProvisioningMachines(ctx, wObj, c.Client)
+	if err != nil {
+		return err
 	}
 
 	// Check the current cluster nodes if they match the labelSelector and instanceType
@@ -153,7 +159,7 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 
 	validNodeCount := len(validNodeList)
 	// subtract all valid nodes from the desired count
-	remainingNodeCount := lo.FromPtr(wObj.Resource.Count) - validNodeCount
+	remainingNodeCount := lo.FromPtr(wObj.Resource.Count) - validNodeCount - machinesProvisioningCount
 
 	// if current valid nodes Count == workspace count, then all good and return
 	if remainingNodeCount == 0 {
@@ -171,14 +177,9 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 
 	// Ensure all nodes plugins are running successfully
 	for i := range validNodeList {
-		if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeInstallNodePlugins, metav1.ConditionFalse, "installNodePlugins",
-			fmt.Sprintf("installing plugins for node %s", validNodeList[i].Name)); err != nil {
-			klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-			return err
-		}
 		err = c.ensureNodePlugins(ctx, wObj, validNodeList[i])
 		if err != nil {
-			if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeInstallNodePlugins, metav1.ConditionFalse,
+			if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionFalse,
 				"installNodePlugins", err.Error()); err != nil {
 				klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
 				return err
@@ -187,6 +188,12 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 		}
 	}
 
+	err = c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionTrue,
+		"installNodePluginsSuccess", "machines plugins have been installed successfully")
+	if err != nil {
+		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
+		return err
+	}
 	// Add the valid nodes names to the WorkspaceStatus.WorkerNodes
 	err = c.updateWorkspaceStatusWithNodeList(ctx, wObj, validNodeList)
 	if err != nil {
@@ -229,8 +236,13 @@ func (c *WorkspaceReconciler) validateCurrentClusterNodes(ctx context.Context, w
 		nodeObj := nodeList.Items[index]
 		foundInstanceType = c.validateNodeInstanceType(ctx, wObj, lo.ToPtr(nodeObj))
 		if foundInstanceType {
-			klog.InfoS("found a current valid node", "name", nodeObj.Name)
-			validCurrentNodeList = append(validCurrentNodeList, lo.ToPtr(nodeObj))
+			_, statusRunning := lo.Find(nodeObj.Status.Conditions, func(condition corev1.NodeCondition) bool {
+				return condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue
+			})
+			if statusRunning {
+				klog.InfoS("found a current valid node", "name", nodeObj.Name)
+				validCurrentNodeList = append(validCurrentNodeList, lo.ToPtr(nodeObj))
+			}
 		}
 	}
 
@@ -254,10 +266,12 @@ func (c *WorkspaceReconciler) validateNodeInstanceType(ctx context.Context, wObj
 	return true
 }
 
+// createAndValidateNode creates a new machine and validates status.
 func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *kdmv1alpha1.Workspace) (*corev1.Node, error) {
+	klog.InfoS("createAndValidateNode", "workspace", klog.KObj(wObj))
 	newMachine := machine.GenerateMachineManifest(ctx, wObj)
 
-	if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineProvisioned, metav1.ConditionFalse,
+	if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineProvisioned, metav1.ConditionUnknown,
 		"machineProvisioning", fmt.Sprintf("machine %s is getting provisioned", newMachine.Name)); err != nil {
 		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
 		return nil, err
@@ -282,32 +296,14 @@ func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *k
 		return nil, err
 	}
 
-	if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionFalse,
-		"checkMachineStatus", fmt.Sprintf("checking machine %s status", newMachine.Name)); err != nil {
+	if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionUnknown,
+		"checkMachineStatusPending", fmt.Sprintf("checking machine %s status", newMachine.Name)); err != nil {
 		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
 		return nil, err
 	}
+
 	// check machine status until it's ready
-	if err := machine.CheckMachineStatus(ctx, newMachine, c.Client); err != nil {
-		if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionFalse,
-			"checkMachineStatusFailed", err.Error()); err != nil {
-			klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-			return nil, err
-		}
-		return nil, err
-	}
-
-	if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionTrue,
-		"checkMachineStatusSuccess", "check machine status successfully"); err != nil {
-		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-		return nil, err
-	}
-
-	nodeName := newMachine.Status.NodeName
-	if nodeName == "" {
-		// TODO retry get machine
-	}
-	nodeObj, err := k8sresources.GetNode(ctx, nodeName, c.Client)
+	err = machine.CheckMachineStatus(ctx, newMachine, c.Client)
 	if err != nil {
 		if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionFalse,
 			"checkMachineStatusFailed", err.Error()); err != nil {
@@ -317,15 +313,11 @@ func (c *WorkspaceReconciler) createAndValidateNode(ctx context.Context, wObj *k
 		return nil, err
 	}
 
-	err = c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeMachineStatus, metav1.ConditionTrue,
-		"installNodePluginsSuccess", "machines plugins have been installed successfully")
-	if err != nil {
-		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-		return nil, err
-	}
-	return nodeObj, nil
+	// get the node object from the machine status nodeName.
+	return k8sresources.GetNode(ctx, newMachine.Status.NodeName, c.Client)
 }
 
+// ensureNodePlugins ensures node plugins (Nvidia and DADI) are installed.
 func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kdmv1alpha1.Workspace, nodeObj *corev1.Node) error {
 	klog.InfoS("EnsureNodePlugins", "node", klog.KObj(nodeObj))
 
@@ -349,7 +341,7 @@ func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kdmv1
 						klog.ErrorS(err, "nvidia plugin cannot be installed, node not found", "node", nodeObj.Name)
 						return err
 					}
-					if err := c.setConditionInstallNodePluginsToUnknown(ctx, wObj, nodeObj); err != nil {
+					if err := c.setConditionMachineProvisionedToUnknown(ctx, wObj, nodeObj); err != nil {
 						return err
 					}
 					time.Sleep(1 * time.Second)
@@ -366,34 +358,16 @@ func (c *WorkspaceReconciler) ensureNodePlugins(ctx context.Context, wObj *kdmv1
 						klog.ErrorS(err, "DADI plugin cannot be installed, node not found", "node", nodeObj.Name)
 						return err
 					}
-					if err := c.setConditionInstallNodePluginsToUnknown(ctx, wObj, nodeObj); err != nil {
+					if err := c.setConditionMachineProvisionedToUnknown(ctx, wObj, nodeObj); err != nil {
 						return err
 					}
 					time.Sleep(1 * time.Second)
 					continue
 				}
 			}
-
-			// Update status
-			if err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeInstallNodePlugins, metav1.ConditionTrue,
-				"InstallNodePluginsSuccess", "node plugins have been installed"); err != nil {
-				klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-				return err
-			}
 			return nil
 		}
 	}
-}
-
-func (c *WorkspaceReconciler) setConditionInstallNodePluginsToUnknown(ctx context.Context, wObj *kdmv1alpha1.Workspace, nodeObj *corev1.Node) error {
-	klog.InfoS("setConditionInstallNodePluginsToUnknown", "workspace", klog.KObj(wObj), "node", klog.KObj(nodeObj))
-	err := c.setWorkspaceStatusCondition(ctx, wObj, kdmv1alpha1.WorkspaceConditionTypeInstallNodePlugins, metav1.ConditionUnknown, "InstallNodePluginsWaiting",
-		fmt.Sprintf("waiting for plugins to get installed on node %s", nodeObj.Name))
-	if err != nil {
-		klog.ErrorS(err, "failed to update workspace status", "workspace", wObj)
-		return err
-	}
-	return nil
 }
 
 func (c *WorkspaceReconciler) applyAnnotations(ctx context.Context, wObj *kdmv1alpha1.Workspace) error {
@@ -408,9 +382,17 @@ func (c *WorkspaceReconciler) applyAnnotations(ctx context.Context, wObj *kdmv1a
 		}
 	}
 
-	//TODO generate more strong random service name
-	serviceObj := k8sresources.GenerateLoadBalancerService(ctx, fmt.Sprint(wObj.Name, "-scv-", rand.Intn(100_000)), wObj.Namespace, serviceType, wObj.Resource.LabelSelector.MatchLabels)
-	err := k8sresources.CreateLoadBalancerService(ctx, serviceObj, c.Client)
+	existingObj, err := k8sresources.GetService(ctx, wObj.Name, wObj.Namespace, c.Client)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	if existingObj != nil {
+		klog.InfoS("a service already exists for workspace", "workspace", klog.KObj(wObj), "serviceType", serviceType)
+		return nil
+	}
+
+	serviceObj := k8sresources.GenerateServiceManifest(ctx, wObj, serviceType)
+	err = k8sresources.CreateService(ctx, serviceObj, c.Client)
 	if err != nil {
 		return err
 	}
@@ -419,8 +401,19 @@ func (c *WorkspaceReconciler) applyAnnotations(ctx context.Context, wObj *kdmv1a
 	return nil
 }
 
+// applyInference applies inference spec.
 func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kdmv1alpha1.Workspace) error {
 	klog.InfoS("applyInference", "service", klog.KObj(wObj))
+
+	existingObj, err := k8sresources.GetDeployment(ctx, wObj.Name, wObj.Namespace, c.Client)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	if existingObj != nil {
+		klog.InfoS("a deployment already exists for workspace", "workspace", klog.KObj(wObj))
+		return nil
+	}
 
 	// TODO check if preset exists, template shouldn't.
 	volume := wObj.Inference.Preset.Volume
@@ -429,14 +422,13 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kdmv1alp
 	}
 
 	presetName := wObj.Inference.Preset.Name
-	var err error
 	switch presetName {
 	case kdmv1alpha1.PresetSetModelllama2A:
-		err = inference.CreateLLAMA2APresetModel(ctx, wObj.Name, wObj.Namespace, wObj.Resource.LabelSelector, volume, torchRunParams, c.Client)
+		err = inference.CreateLLAMA2APresetModel(ctx, wObj, volume, torchRunParams, c.Client)
 	case kdmv1alpha1.PresetSetModelllama2B:
-		err = inference.CreateLLAMA2BPresetModel(ctx, wObj.Name, wObj.Namespace, wObj.Resource.LabelSelector, volume, torchRunParams, c.Client)
+		err = inference.CreateLLAMA2BPresetModel(ctx, wObj, volume, torchRunParams, c.Client)
 	case kdmv1alpha1.PresetSetModelllama2C:
-		err = inference.CreateLLAMA2CPresetModel(ctx, wObj.Name, wObj.Namespace, wObj.Resource.LabelSelector, volume, torchRunParams, c.Client)
+		err = inference.CreateLLAMA2CPresetModel(ctx, wObj, volume, torchRunParams, c.Client)
 	default:
 		err = fmt.Errorf("preset model %s is not supported", presetName)
 		klog.ErrorS(err, "no inference has been created")
@@ -446,6 +438,8 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kdmv1alp
 	}
 	return nil
 }
+
+// SetupWithManager sets up the controller with the Manager.
 func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c.Recorder = mgr.GetEventRecorderFor("Workspace")
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{}, "spec.nodeName", func(rawObj client.Object) []string {
@@ -454,8 +448,27 @@ func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return err
 	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kdmv1alpha1.Workspace{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(
+			&v1alpha5.Machine{}, c.watchMachines()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 5}).
 		Complete(c)
+}
+
+// watches	for machine with label LabelCreatedByWorkspace equals workspace name.
+func (c *WorkspaceReconciler) watchMachines() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, o client.Object) []reconcile.Request {
+			machineObj := o.(*v1alpha5.Machine)
+			return []reconcile.Request{
+				{
+					NamespacedName: client.ObjectKey{
+						Name:      machineObj.Name,
+						Namespace: machineObj.Namespace,
+					},
+				},
+			}
+		})
 }

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -110,11 +110,11 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 	klog.InfoS("applyWorkspaceResource", "workspace", klog.KObj(wObj))
 	validNodeList := []*corev1.Node{}
 
-	// Set resource count to 1 if it's not set
-	if lo.FromPtr(wObj.Resource.Count) == 0 {
-		klog.InfoS("resource count is not set, default (count = 1) will be used", "workspace", klog.KObj(wObj))
-		wObj.Resource.Count = lo.ToPtr(1)
-	}
+	//// Set resource count to 1 if it's not set
+	//if lo.FromPtr(wObj.Resource.Count) == 0 {
+	//	klog.InfoS("resource count is not set, default (count = 1) will be used", "workspace", klog.KObj(wObj))
+	//	wObj.Resource.Count = lo.ToPtr(1)
+	//}
 
 	machinesProvisioningCount, err := machine.CheckOngoingProvisioningMachines(ctx, wObj, c.Client)
 	if err != nil {

--- a/pkg/k8sresources/deployments.go
+++ b/pkg/k8sresources/deployments.go
@@ -3,6 +3,7 @@ package k8sresources
 import (
 	"context"
 
+	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,28 +22,53 @@ func CreateDeployment(ctx context.Context, deploymentObj *appsv1.Deployment, kub
 	})
 }
 
-func GenerateDeploymentManifest(ctx context.Context, depName, namespace, imageName string,
-	replicas int, labelSelector *v1.LabelSelector, commands []string, containerPorts []corev1.ContainerPort,
+func GetDeployment(ctx context.Context, name, namespace string, kubeClient client.Client) (*appsv1.Deployment, error) {
+	klog.InfoS("GetDeployment", "deploymentName", name, "deploymentNamespace", namespace)
+
+	dep := &appsv1.Deployment{}
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		return kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, dep, &client.GetOptions{})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return dep, nil
+}
+
+func GenerateDeploymentManifest(ctx context.Context, workspaceObj *kdmv1alpha1.Workspace, imageName string,
+	replicas int, commands []string, containerPorts []corev1.ContainerPort,
 	livenessProbe, readinessProbe *corev1.Probe, resourceRequirements corev1.ResourceRequirements,
 	volumeMount []corev1.VolumeMount, tolerations []corev1.Toleration, volumes []corev1.Volume) *appsv1.Deployment {
-	klog.InfoS("GenerateDeploymentManifest", "deployment", depName, "namespace", namespace, "image", imageName)
+	klog.InfoS("GenerateDeploymentManifest", "workspace", klog.KObj(workspaceObj), "image", imageName)
 
 	return &appsv1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      depName,
-			Namespace: namespace,
+			Name:      workspaceObj.Name,
+			Namespace: workspaceObj.Namespace,
+			OwnerReferences: []v1.OwnerReference{
+				{
+					APIVersion: kdmv1alpha1.SchemeBuilder.GroupVersion.String(),
+					Kind:       "Workspace",
+					UID:        workspaceObj.UID,
+					Name:       workspaceObj.Name,
+				},
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: lo.ToPtr(int32(replicas)),
-			Selector: labelSelector,
+			Selector: workspaceObj.Resource.LabelSelector,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: labelSelector.MatchLabels,
+					Labels: workspaceObj.Resource.LabelSelector.MatchLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:           depName,
+							Name:           workspaceObj.Name,
 							Image:          imageName,
 							Command:        commands,
 							Resources:      resourceRequirements,
@@ -54,7 +80,7 @@ func GenerateDeploymentManifest(ctx context.Context, depName, namespace, imageNa
 					},
 					Tolerations:  tolerations,
 					Volumes:      volumes,
-					NodeSelector: labelSelector.MatchLabels,
+					NodeSelector: workspaceObj.Resource.LabelSelector.MatchLabels,
 				},
 			},
 		},

--- a/pkg/k8sresources/nodes.go
+++ b/pkg/k8sresources/nodes.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	NvidiaDaemonSetName          = "nvidia-device-plugin-daemonset"
 	LabelKeyNvidia               = "accelerator"
 	LabelValueNvidia             = "nvidia"
 	CapacityNvidiaGPU            = "nvidia.com/gpu"
@@ -40,7 +39,7 @@ func GetNode(ctx context.Context, nodeName string, kubeClient client.Client) (*c
 
 // ListNodes get list of kubernetes nodes
 func ListNodes(ctx context.Context, kubeClient client.Client, options *client.ListOptions) (*corev1.NodeList, error) {
-	klog.InfoS("ListNodes")
+	klog.InfoS("ListNodes", "listOptions", options)
 	nodeList := &corev1.NodeList{}
 
 	err := kubeClient.List(ctx, nodeList, options)

--- a/pkg/k8sresources/services.go
+++ b/pkg/k8sresources/services.go
@@ -3,6 +3,7 @@ package k8sresources
 import (
 	"context"
 
+	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -11,8 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateLoadBalancerService(ctx context.Context, serviceObj *v1.Service, kubeClient client.Client) error {
-	klog.InfoS("CreateLoadBalancerService", "service", klog.KObj(serviceObj))
+func CreateService(ctx context.Context, serviceObj *v1.Service, kubeClient client.Client) error {
+	klog.InfoS("CreateService", "service", klog.KObj(serviceObj))
 	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return true
 	}, func() error {
@@ -20,16 +21,41 @@ func CreateLoadBalancerService(ctx context.Context, serviceObj *v1.Service, kube
 	})
 }
 
-func GenerateLoadBalancerService(ctx context.Context, serviceName, namespace string, serviceType v1.ServiceType, labelSelector map[string]string) *v1.Service {
-	klog.InfoS("GenerateLoadBalancerService", "serviceName", serviceName, "namespace", "serviceType", serviceType)
+func GetService(ctx context.Context, name, namespace string, kubeClient client.Client) (*v1.Service, error) {
+	klog.InfoS("GetService", "serviceName", name, "serviceNamespace", namespace)
+
+	svc := &v1.Service{}
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		return kubeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, svc, &client.GetOptions{})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return svc, nil
+}
+
+func GenerateServiceManifest(ctx context.Context, workspaceObj *kdmv1alpha1.Workspace, serviceType v1.ServiceType) *v1.Service {
+	klog.InfoS("GenerateServiceManifest", "workspace", klog.KObj(workspaceObj), "serviceType", serviceType)
 
 	return &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceName,
-			Namespace: namespace,
+			Name:      workspaceObj.Name,
+			Namespace: workspaceObj.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kdmv1alpha1.SchemeBuilder.GroupVersion.String(),
+					Kind:       "Workspace",
+					UID:        workspaceObj.UID,
+					Name:       workspaceObj.Name,
+				},
+			},
 		},
 		Spec: v1.ServiceSpec{
-			Type: serviceType, //v1.ServiceTypeLoadBalancer,
+			Type: serviceType,
 			Ports: []v1.ServicePort{
 				{
 					Protocol:   v1.ProtocolTCP,
@@ -37,7 +63,7 @@ func GenerateLoadBalancerService(ctx context.Context, serviceName, namespace str
 					TargetPort: intstr.FromInt(5000),
 				},
 			},
-			Selector: labelSelector,
+			Selector: workspaceObj.Resource.LabelSelector.MatchLabels,
 		},
 	}
 }


### PR DESCRIPTION
- Remove machine condition `WorkspaceConditionTypeInstallNodePlugins` and use `WorkspaceConditionTypeMachineProvisioned` instead.
- Check if service and inference deployment already exist.
- Check if any machines are in the provisioning state: 
   - Subtract them from the number of machines that need to be created.
   - Wait for condition `MachineStatus` to be `True` if machine requirements has the `workspace.resource.instancetype`. 
- Add `ownerRef` for service and deployment objects that were created by the workspace CR. 

Sample for the current workspace status:

```yaml
Status:
  Condition:
    Last Transition Time:  2023-09-06T03:06:56Z
    Message:               machine has been provisioned successfully
    Observed Generation:   1
    Reason:                machineProvisionSuccess
    Status:                True
    Type:                  MachineProvisioned
    Last Transition Time:  2023-09-06T03:13:34Z
    Message:               machines plugins have been installed successfully
    Observed Generation:   1
    Reason:                installNodePluginsSuccess
    Status:                True
    Type:                  MachineReady
    Last Transition Time:  2023-09-06T03:13:34Z
    Message:               workspace resource is ready
    Observed Generation:   1
    Reason:                workspaceResourceDeployedSuccess
    Status:                True
    Type:                  ResourceProvisioned
```