### PR TITLE
fix: Update conditions to reflect return errors

### DIFF
--- a/examples/kdm_workspace_llama2_70b.yaml
+++ b/examples/kdm_workspace_llama2_70b.yaml
@@ -5,7 +5,8 @@ metadata:
     kubernetes-kdm.io/service-type: load-balancer
   name: workspace-llama-70b-aks
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC96ads_A100_v4"
+  count: 2
   labelSelector:
     matchLabels:
       apps: llama-70b

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	//	machineStatusCheckInterval is the interval to check the machine status.
-	machineStatusCheckInterval = 60 * time.Second
+	machineStatusCheckInterval = 180 * time.Second
 )
 
 // GenerateMachineManifest generates a machine object from	the given workspace.


### PR DESCRIPTION
- Update conditions in the `addOrUpdateWorkspace` func to reflect the returned errors.
- Update instance type and count in llama2-70b example.
- Increase the machine check status interval.